### PR TITLE
Speed improvement reading ese db

### DIFF
--- a/dissect/esedb/record.py
+++ b/dissect/esedb/record.py
@@ -166,7 +166,7 @@ class RecordData:
         value = None
         tag_field = None
 
-        if not self.header:
+        if self.header is None:
             return value
 
         if column.is_fixed:


### PR DESCRIPTION
Hi, first up thanks for providing the ESE reader to the community! After noticing some very slow reading on large ESE databases, I did some debugging to find this bottleneck.

A call to `self.header` in record.py that checks for its existence results in several other calls to read the data for no reason if it does exist! This quick fix now correctly just checks for `None`.

The resulting speed improvement is 2x due to removing the time-consuming and extra reads on each record read on at least some large ese databases I have. 

**Testing results**:

```
PREVIOUSLY
=====================================
1000 row fetch time = 00:00:51.165512
=====================================
NOW
=====================================
1000 row fetch time = 00:00:23.718492
=====================================
```