### PR TITLE
Add AttributeError to except ImportError statements

### DIFF
--- a/dissect/esedb/tools/impacket.py
+++ b/dissect/esedb/tools/impacket.py
@@ -9,6 +9,7 @@ from dissect.esedb.record import Record
 try:
     from impacket import ese
 except (AttributeError, ImportError):
+    print("This utility monkeypatches ESENT_DB from impacket, but impacket is not installed", file=sys.stderr)
     exit(1)
 
 


### PR DESCRIPTION
In some cases windows throws an AttributeError instead of an ImportError during an import