### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/esedb/esedb.py
+++ b/dissect/esedb/esedb.py
@@ -31,8 +31,6 @@ class EseDB:
         self.fh = fh
         self.impacket_compat = impacket_compat
 
-        self.page = lru_cache(maxsize=4096)(self.page)
-
         self.header = c_esedb.DBFILEHDR(fh)
         if self.header.ulMagic != ulDAEMagic:
             raise InvalidDatabase("invalid file header signature")
@@ -46,6 +44,8 @@ class EseDB:
             raise InvalidDatabase("unsupported format revision")
 
         self.catalog = Catalog(self, pgnoFDPMSO)
+
+        self.page = lru_cache(4096)(self.page)
 
     @cached_property
     def has_small_pages(self) -> bool:

--- a/dissect/esedb/record.py
+++ b/dissect/esedb/record.py
@@ -90,9 +90,6 @@ class RecordData:
         self.node = node
         self.data = node.data
 
-        self._get_tag_field = lru_cache(4096)(self._get_tag_field)
-        self._find_tag_field_idx = lru_cache(4096)(self._find_tag_field_idx)
-
         self.header = None
         self._values = {}
 
@@ -153,6 +150,9 @@ class RecordData:
                 self._tagged_data_count = first_tagged_field.offset // 4  # sizeof(TAGFLD)
                 self._tagged_data_view = xmemoryview(tagged_field_data, "<I")
                 self._tagged_fields[first_tagged_field.identifier] = first_tagged_field
+
+        self._get_tag_field = lru_cache(4096)(self._get_tag_field)
+        self._find_tag_field_idx = lru_cache(4096)(self._find_tag_field_idx)
 
     def get(self, column: Column, raw: bool = False) -> RecordValue:
         """Retrieve the value for the specified column.


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)